### PR TITLE
fix: align ShortenerForm inputs to flex-end

### DIFF
--- a/astro/src/components/ShortenerForm.astro
+++ b/astro/src/components/ShortenerForm.astro
@@ -21,7 +21,7 @@ const { onSuccess, onError } = Astro.props;
 	}
 	form div {
 		display: flex;
-		align-items: end; /* Or flex-end */
+                align-items: flex-end;
 		padding-bottom: 2em;
 		gap: 0.5em; /* Add some space between inputs */
 	}

--- a/dist/index.html
+++ b/dist/index.html
@@ -28,11 +28,12 @@
 		form, #resultcontainer {
 			height: 50%;
 		}
-		form div {
-			display: flex;
-			align-items: end;
-			padding-bottom: 2em;
-		}
+                form div {
+                        display: flex;
+                        align-items: flex-end;
+                        padding-bottom: 2em;
+                        gap: 0.5em;
+                }
 		#resultcontainer {
 			display: flex;
 			justify-content: start;


### PR DESCRIPTION
## Summary
- use `align-items: flex-end` in ShortenerForm styles
- update built `dist` CSS to match

## Testing
- `pnpm run build` *(fails: The argument 'path' must be a string, Uint8Array, or URL without null bytes)*
- `pnpm test` *(fails: Network connection lost)*

------
https://chatgpt.com/codex/tasks/task_e_688e4c237550832a9279462215c7f225