### PR TITLE
Clarify deterministic hash behavior in query parameter test

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -72,13 +72,13 @@ describe('fuc.moe shortener with in-memory KV', () => {
 		expect(response.status).toBe(404); // It should fall through to redirect logic, which 404s
 	});
 
-	it('preserves query params and fragments in URL', async () => {
-		const url = 'https://example.com/page?foo=1#bar';
-		const expectedHash = 'rhFG'; // Whatever it hashes to
+        it('preserves query params and fragments in URL', async () => {
+                const url = 'https://example.com/page?foo=1#bar';
+                const expectedHash = 'rhFG'; // Deterministic hash from modified DJB2 algorithm (hashUrl)
 
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(makeRequest(url), env, ctx);
-		await waitOnExecutionContext(ctx);
+                const ctx = createExecutionContext();
+                const response = await worker.fetch(makeRequest(url), env, ctx);
+                await waitOnExecutionContext(ctx);
 
 		expect(await response.text()).toBe(expectedHash);
 	});


### PR DESCRIPTION
## Summary
- Clarify that the expected hash in the query/fragment test is deterministically generated using a modified DJB2 algorithm

## Testing
- `pnpm exec vitest run` *(fails: Error: Network connection lost)*

------
https://chatgpt.com/codex/tasks/task_e_688e4cc56668832a98bd612c6495de27