### PR TITLE
Fix plus sign handling in custom slug URLs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,13 @@
 import shortenUrl from './utils.ts';
 
 async function handlePlusUrl(path: string, request: Request, env: Env): Promise<Response> {
-	const [hash, url] = path.split('+');
+        // Only split on the first '+' to preserve additional '+' characters in the URL
+        const plusIndex = path.indexOf('+');
+        const hash = path.slice(0, plusIndex);
+        const url = path.slice(plusIndex + 1);
 
-	// Use full URL with query params and fragment
-	const fullUrl = new URL(url, request.url).href;
+        // Use full URL with query params and fragment
+        const fullUrl = new URL(url, request.url).href;
 
 	if (!URL.canParse(fullUrl)) {
 		return new Response('Error: Invalid URL', { status: 400 });


### PR DESCRIPTION
## Summary
- Split `hash+url` pairs at the first plus to keep additional `+` characters in the destination URL
- Add regression test ensuring URLs with `+` are stored and redirected correctly

## Testing
- `pnpm test` *(fails: Network connection lost in heavy collision test)*

------
https://chatgpt.com/codex/tasks/task_e_688e4cbf32f4832abd47bc673eaeb7da